### PR TITLE
fix: tradingview history API

### DIFF
--- a/bitkub/constants.py
+++ b/bitkub/constants.py
@@ -8,7 +8,7 @@ ENDPOINTS = {
     "MARKET_BIDS_PATH": "/api/market/bids?sym={sym}&lmt={lmt}",
     "MARKET_ASKS_PATH": "/api/market/asks?sym={sym}&lmt={lmt}",
     "MARKET_BOOKS_PATH": "/api/market/books?sym={sym}&lmt={lmt}",
-    "MARKET_TRADING_VIEW_PATH": "/api/market/tradingview?sym={sym}&int={int}&frm={frm}&to={to}",
+    "MARKET_TRADING_VIEW_PATH": "/tradingview/history?symbol={sym}&resolution={int}&from={frm}&to={to}",
     "MARKET_DEPTH_PATH": "/api/market/depth?sym={sym}&lmt={lmt}",
     "MARKET_WALLET": "/api/market/wallet",
     "MARKET_BALANCES": "/api/market/balances",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 
 setup(
     name='bitkub',
-    version='1.0.3',
+    version='1.0.4',
     description='A Python library for Bitkub API',
     long_description=readme(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
update tradingview history API follow new document
[git push --set-upstream origin fix-tradingview-history-api](https://github.com/bitkub/bitkub-official-api-docs/blob/master/restful-api.md#get-tradingviewhistory)